### PR TITLE
Change autoload location reference

### DIFF
--- a/sproutformsgooglerecaptcha/services/SproutFormsGoogleRecaptchaService.php
+++ b/sproutformsgooglerecaptcha/services/SproutFormsGoogleRecaptchaService.php
@@ -13,7 +13,7 @@
 
 namespace Craft;
 
-require_once './../craft/plugins/sproutformsgooglerecaptcha/vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 class SproutFormsGoogleRecaptchaService extends BaseApplicationComponent
 {


### PR DESCRIPTION
Amended to allow for the plugins folder not always to be necessary as a child of '/craft'. Referenced in issue #5 